### PR TITLE
Fix yard generating

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,11 +66,43 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK }}
           matrix: ${{ toJson(matrix) }}
 
+  yard:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - uses: ruby/setup-ruby@ae195bbe749a7cef685ac729197124a48305c1cb # v1.276.0
+        with:
+          ruby-version: ruby
+          bundler-cache: true
+
+      - name: bundle update
+        run: |
+          set -xe
+          bundle config path vendor/bundle
+          bundle update --all --jobs $(nproc) --retry 3
+
+      - name: yard generating test
+        run: |
+          set -xe
+          bundle exec yard
+          ls -ld doc/
+
+      - name: Slack Notification (not success)
+        uses: act10ns/slack@cfcc30955fe9377f4f55e1079e5419ee1014269f # v2
+        if: "! success()"
+        continue-on-error: true
+        with:
+          status: ${{ job.status }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+
   all-pass:
     if: always()
 
     needs:
       - test
+      - yard
 
     runs-on: ubuntu-slim
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
-      - run: bundle update --jobs $(nproc) --retry 3
+      - run: bundle update --all --jobs $(nproc) --retry 3
 
       - run: bundle exec rspec
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,22 +40,7 @@ jobs:
 
       - run: bundle update --jobs $(nproc) --retry 3
 
-      - name: Setup Code Climate Test Reporter
-        uses: aktions/codeclimate-test-reporter@7634aa9ac7883182f583f15ff7b6ff519939dd0a # v1.2.0
-        with:
-          codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
-          command: before-build
-        continue-on-error: true
-
       - run: bundle exec rspec
-
-      - name: Teardown Code Climate Test Reporter
-        uses: aktions/codeclimate-test-reporter@7634aa9ac7883182f583f15ff7b6ff519939dd0a # v1.2.0
-        with:
-          codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
-          command: after-build
-        if: always()
-        continue-on-error: true
 
       - name: Slack Notification (not success)
         uses: act10ns/slack@cfcc30955fe9377f4f55e1079e5419ee1014269f # v2

--- a/prismdb.gemspec
+++ b/prismdb.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday-mashify"
 
   spec.add_development_dependency "coveralls_reborn"
+  spec.add_development_dependency "irb"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rdoc"
   spec.add_development_dependency "rspec"

--- a/prismdb.gemspec
+++ b/prismdb.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "coveralls_reborn"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rdoc"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-its"
 


### PR DESCRIPTION
https://github.com/sue445/prismdb-ruby/actions/runs/20521702325/job/58957965068

```
Run bundle exec yard --output-dir "${DOC_DIR}"
/home/runner/work/prismdb-ruby/prismdb-ruby/vendor/bundle/ruby/4.0.0/gems/yard-0.9.38/lib/yard/templates/helpers/markup_helper.rb:105: warning: rdoc used to be loaded from the standard library, but is not part of the default gems since Ruby 4.0.0.
You can add rdoc to your Gemfile or gemspec to fix this error.
Error: : Missing 'redcarpet' gem for Markdown formatting. Install it with `gem install redcarpet`
```